### PR TITLE
Tidy dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,10 +8,6 @@ Authors@R:
            email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).
-Depends: 
-  TMB, 
-  RcppEigen, 
-  ktools
 LinkingTo: 
   TMB, 
   RcppEigen, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,16 @@ Authors@R:
            email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).
-Depends: TMB, RcppEigen, ktools
-LinkingTo: TMB, RcppEigen, ktools
+Depends: 
+  TMB, 
+  RcppEigen, 
+  ktools
+LinkingTo: 
+  TMB, 
+  RcppEigen, 
+  ktools
+Remotes:
+    kklot/ktools  
 License: What license it uses
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This PR makes two changes:

* Adds `kklot/ktools` to the `Remotes:` in package DESCRIPTION. Then install packages knows where to install this from.
* Removes packages from `Depends:` in the DESCRIPTION. You only need `LinkingTo:` for compiling the source code.

Later when starting to write some R functions, in general it is best practice to put packages in `Imports:` rather than `Depends:`. The latter imports the entire package into your namespace.